### PR TITLE
Include toc-title in the hpstr theme

### DIFF
--- a/inst/resources/templates/hpstr.html
+++ b/inst/resources/templates/hpstr.html
@@ -473,6 +473,9 @@ $if(toc_float)$
 <!-- setup 3col/9col grid for toc_float and main content  -->
 <div class="row-fluid">
 <div class="col-xs-12 col-sm-4 col-md-3">
+$if(toc-title)$
+<h2 id="$idprefix$toc-title">$toc-title$</h2>
+$endif$
 <div id="$idprefix$TOC" class="tocify">
 </div>
 </div>
@@ -560,6 +563,9 @@ $if(toc_float)$
 $else$
 $if(toc)$
 <div id="$idprefix$TOC" class="toc">
+$if(toc-title)$
+<h2 id="$idprefix$toc-title" class="toc-title">$toc-title$</h2>
+$endif$
 $toc$
 </div>
 $endif$


### PR DESCRIPTION
Hi @yixuan! 

Thank you for putting this package together. 

Trying to add a `toc-title` under theme `hpstr` fails because the html template for this theme doesn't take into consideration this parameter. This PR should fix this issue (& partially fixes https://github.com/yixuan/prettydoc/issues/20). *Note*: I didn't change the styling (i.e., css) of the toc-title.