### PR TITLE
focus scope of :first-child in .main-content

### DIFF
--- a/not_in_package/cayman/cayman.scss
+++ b/not_in_package/cayman/cayman.scss
@@ -256,7 +256,7 @@ a {
   //-
   // word-wrap: break-word;
 
-  :first-child {
+  > :first-child {
     margin-top: 0;
   }
 


### PR DESCRIPTION
Stop descending `:first-child` down to other child elements' first-child in `.main-content` and focus only on `.main-content`.

It is debatable if one would like this space decreased at all, but that would be a design decision. By scoping the `:first-child` in the scss/css selector with `>` we do not interfere with RMarkdown/knitr blocks down the dom.

I therefore would see this fix fit.