### PR TITLE
Add toc-title to the leonids theme

### DIFF
--- a/inst/resources/templates/leonids.html
+++ b/inst/resources/templates/leonids.html
@@ -476,6 +476,9 @@ $if(toc_float)$
 <!-- setup 3col/9col grid for toc_float and main content  -->
 <div class="row-fluid">
 <div class="col-xs-12 col-sm-4 col-md-3">
+$if(toc-title)$
+<h2 id="$idprefix$toc-title">$toc-title$</h2>
+$endif$
 <div id="$idprefix$TOC" class="tocify">
 </div>
 </div>
@@ -561,6 +564,9 @@ $if(toc_float)$
 $else$
 $if(toc)$
 <div id="$idprefix$TOC" class="toc">
+$if(toc-title)$
+<h2 id="$idprefix$toc-title" class="toc-title">$toc-title$</h2>
+$endif$
 $toc$
 </div>
 $endif$


### PR DESCRIPTION
Hi @yixuan et al., I love the prettydoc themes =) 

I have been working with the **leonids** one and needed to add a title to the table of contents. This PR adds the `toc-title` to the **leonids** template.

Happy to make any other changes needed!

_Note:_ Issue related #20.